### PR TITLE
Add var env package_dir to change build dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.14
 ENV CGO_ENABLED 1
 ENV GOFLAGS '-mod=vendor'
 ENV GO_NO_DEBUG ''
+ENV PACKAGE_DIR '.'
 
 RUN apt update && apt install -y inotify-tools
 RUN go get github.com/derekparker/delve/cmd/dlv

--- a/watch.sh
+++ b/watch.sh
@@ -31,7 +31,7 @@ doRun() {
     dlv debug --wd /app --listen=:40000 --output=/tmp/debug_bin --headless=true --api-version=2 --log &
   else
     rm -f /tmp/run_bin
-    (cd /app && go build -race -o /tmp/run_bin)
+    (cd /app && go build -race -o /tmp/run_bin $PACKAGE_DIR)
     if [ -f /tmp/run_bin ]; then
       (cd /app && /tmp/run_bin &)
     else


### PR DESCRIPTION
My apps are using these Golang standards for packages https://github.com/golang-standards/project-layout, so my `main.go` file is inside `cmd/app`. I'm adding a var env to change build package dir if is necessary.

You do you think?

Thank you for this contribution.