### PR TITLE
Fix debugger on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following env variables are available:
 * `GO_NO_DEBUG` - set it to anything except empty value to disable debugging, leaving only hot-reload on code changes
 * `GOMON_DIED_CHECK_INTERVAL` - (in seconds, default: **2**s) monitor will check if APP is alive with set interval
 * `GOMON_IGNORE` - extended regex to exclude files being watched
+* `GO_DEBUG_STARTUP_RETRIES` - max amount of 10-sec sleep iterations to give debugger time to properly set up, while running without  `GO_NO_DEBUG`. Defaults to `6`
 
 ## Ports
 

--- a/check-alive.sh
+++ b/check-alive.sh
@@ -14,6 +14,12 @@ notifyAppDied() {
     echo "$(timestmp)Application died, restarting..."
 }
 
+DEBUG_RETRIES="${GO_DEBUG_STARTUP_RETRIES}"
+if [ -z "${GO_DEBUG_STARTUP_RETRIES}" ]; then
+  DEBUG_RETRIES="6"
+fi
+
+
 runForever() {
   sleep 10
   IS_DEBUG="${1}"
@@ -22,7 +28,7 @@ runForever() {
     if [ "${IS_DEBUG}" = "true" ]; then
       if [ -z "$(pidof dlv)" ] || [ -z "$(pidof debug_bin)" ]; then
         j=0
-        while [ $j -le 6 ]; do
+        while [ $j -lt ${DEBUG_RETRIES} ]; do
             echo "$(timestmp)Something is not up, giving another try"
             sleep 10
             if [ "$(pidof dlv)" ] && [ "$(pidof debug_bin)" ]; then

--- a/check-alive.sh
+++ b/check-alive.sh
@@ -21,6 +21,18 @@ runForever() {
     sleep $GOMON_DIED_CHECK_INTERVAL
     if [ "${IS_DEBUG}" = "true" ]; then
       if [ -z "$(pidof dlv)" ] || [ -z "$(pidof debug_bin)" ]; then
+        j=0
+        while [ $j -le 6 ]; do
+            echo "$(timestmp)Something is not up, giving another try"
+            sleep 10
+            if [ "$(pidof dlv)" ] && [ "$(pidof debug_bin)" ]; then
+              break
+            fi
+            j=$(( j + 1 ))
+        done
+        if [ "$(pidof dlv)" ] && [ "$(pidof debug_bin)" ]; then
+          continue
+        fi
         notifyAppDied
         kill -s USR1 1 &
       fi


### PR DESCRIPTION
# Problem
[On the issues page](https://github.com/vadzappa/gomon-docker/issues/4)

# Solution
When checking app aliveness with enabled debugger, give it more time to be set up in case either `dlv` or  `debug_bin` are empty.
New env variable (defaulting to 6) can be used to specify amount of iterations in sleep-loop.